### PR TITLE
Create benchmark and GitHub workflow to run it on PRs

### DIFF
--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -1,0 +1,29 @@
+name: Run benchmarks
+on:
+    pull_request:
+        paths:
+            - "src/**"
+            - "benchmark/**"
+            - "*.toml"
+concurrency:
+    # Skip intermediate builds: always.
+    # Cancel intermediate builds: only if it is a pull request build.
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+jobs:
+    benchmark:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - uses: julia-actions/setup-julia@latest
+              with:
+                  version: 1
+            - uses: julia-actions/julia-buildpkg@latest
+            - name: Install dependencies
+              run: julia -e 'using Pkg; pkg"add PkgBenchmark BenchmarkCI@0.1"'
+            - name: Run benchmarks
+              run: julia -e 'using BenchmarkCI; BenchmarkCI.judge(baseline="origin/main")'
+            - name: Post results
+              run: julia -e 'using BenchmarkCI; BenchmarkCI.postjudge()'
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /docs/Manifest.toml
 /docs/build/
 env
+/.benchmarkci
+/benchmark/*.json

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+TulipaBulb = "5d7bd171-d18e-45a5-9111-f1f11ac5d04d"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,29 @@
+using BenchmarkTools
+using TulipaBulb
+
+const SUITE = BenchmarkGroup()
+
+SUITE["io"] = BenchmarkGroup(["data", "input", "output"])
+SUITE["model"] = BenchmarkGroup(["model"])
+
+const INPUT_FOLDER = joinpath(@__DIR__, "..", "test", "inputs")
+const OUTPUT_FOLDER = joinpath(@__DIR__, "..", "test", "outputs")
+
+SUITE["io"]["input"] = @benchmarkable begin
+    create_parameters_and_sets_from_file($INPUT_FOLDER)
+end
+parameters, sets = create_parameters_and_sets_from_file(INPUT_FOLDER)
+
+SUITE["model"]["all"] = @benchmarkable begin
+    optimise_investments($parameters, $sets)
+end
+
+solution = optimise_investments(parameters, sets)
+
+SUITE["io"]["output"] = @benchmarkable begin
+    save_solution_to_file(
+        $OUTPUT_FOLDER,
+        $(solution.v_investment),
+        $(parameters.p_unit_capacity),
+    )
+end

--- a/src/model.jl
+++ b/src/model.jl
@@ -6,7 +6,7 @@ export optimise_investments
 This is a doc for optimise_investments.
 It should probably be improved.
 """
-function optimise_investments(params, sets)
+function optimise_investments(params, sets; verbose = false)
     # Sets unpacking
     A = sets.s_assets
     Ac = sets.s_assets_consumer
@@ -18,6 +18,7 @@ function optimise_investments(params, sets)
 
     # Model
     model = Model(HiGHS.Optimizer)
+    set_attribute(model, "output_flag", verbose)
 
     # Variables
     @variable(model, 0 ≤ v_flow[F, RP, K])         #flow from asset a to asset aa [MW]
@@ -66,9 +67,6 @@ function optimise_investments(params, sets)
 
     # Solve model
     optimize!(model)
-
-    # Objective function value
-    println("Total cost: ", objective_value(model))
 
     return (
         objective_value = objective_value(model),


### PR DESCRIPTION
# Pull request details

## Describe the changes made in this pull request

Creates a benchmark suite in file `benchmark/benchmarks.jl`.
Creates a workflow to run the benchmark when there is a new relevant pull request.
The workflow compares the current pull request with `origin/main`.
The comparison is posted in the pull request. An example can be seen here: https://github.com/abelsiqueira/TulipaBulb.jl/pull/2#issuecomment-1684434428

One alternative would be running only when a specific comment is written at a pull request. For instance, writing "/benchmark" starts the benchmark. This adds an extra step and, in return, we avoid running benchmarks for every new PR. Should we leave for later?

<!-- include screenshots if that helps the review -->

## List of related issues or pull requests

Closes #13 

## Collaboration confirmation

As a contributor I confirm

- [x] I read and followed the instructions in README.dev.md
- [x] The documentation is up to date with the changes introduced in this Pull Request (or NA)
- [x] Tests are passing
- [x] Lint is passing
